### PR TITLE
Add ATAC-seq support to the pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,5 @@ test-data-prep/
 NOTES.local.md
 
 # Auto-generated config files
-config/analysis_samplefile_*.tsv
+config/test_samples_*.tsv
 config/config_test_local.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,5 @@ test-data-prep/
 NOTES.local.md
 
 # Auto-generated config files
-config/test_samples_*.tsv
+config/analysis_samplefile_*.tsv
 config/config_test_local.yaml

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -377,7 +377,7 @@ resources:
   find_motifs_in_file: *heavy
   make_peak_stats: *low
   # ATACseq
-  atac_shift_and_bed: *heavy
+  atac_shift_and_bed: *low
   calling_peaks_atac: *heavy
   make_coverage_atac: *heavy
   # mC

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -103,10 +103,11 @@ adapter2:
 
 # Mapping option default
 chip_mapping_option: "default" # options: [ 'default' | 'repeat' | 'repeatall' | 'all' ]
+atac_mapping_option: "default" # options: [ 'default' | 'repeat' | 'repeatall' | 'all' ]
 
-# ChIP-seq parameters
+# Bowtie2-based mapping parameters (shared by ChIP, TF, and ATAC)
 # For mapping
-chip_mapping:
+bt2_mapping_strategy:
   default:
     map_pe: "--end-to-end --maxins 1500"
     map_se: "--end-to-end"
@@ -129,6 +130,10 @@ chip_tracks:
   binsize: 1
   params: "--scaleFactorsMethod None --normalizeUsing CPM --extendReads 300"
 
+atac_tracks:
+  binsize: 1
+  params: "--normalizeUsing CPM"
+
 # For peaks
 chip_callpeaks:
   # To link the type of IP with the type of peaks. Can be updated with other marks. If creating regex patterns, make sure to escape "." with "\."
@@ -137,7 +142,11 @@ chip_callpeaks:
     'H3K27ac|H3K4me3|H3K9ac|H4K16ac|H3K23ac|MNase': "narrow" 
     'H3|H4': "broad"
   params: "--keep-dup 'all' --nomodel"
- 
+
+atac_callpeaks:
+  peaktype: "narrow"
+  params: "--keep-dup 'all' --nomodel --shift 75 --extsize 150"
+
 # RNA parameters
 rna_tracks:
   RNAseq:
@@ -237,6 +246,7 @@ heatmaps_plot_params:
   RNA: "--colorMap seismic --interpolationMethod bilinear"
   sRNA: "--colorMap seismic --interpolationMethod bilinear"
   mC: "--colorMap Oranges --missingDataColor 0.9 --interpolationMethod nearest"
+  ATAC: "--colorMap seismic --interpolationMethod bilinear"
 heatmaps:
   regions:
     base: "scale-regions --missingDataAsZero --skipZeros"
@@ -366,6 +376,10 @@ resources:
   best_peaks_pseudoreps: *low
   find_motifs_in_file: *heavy
   make_peak_stats: *low
+  # ATACseq
+  atac_shift_and_bed: *heavy
+  calling_peaks_atac: *heavy
+  make_coverage_atac: *heavy
   # mC
   make_bismark_indices: *heavy
   bismark_map_pe: *heavy

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -328,6 +328,13 @@ heavy_resources: &heavy
   mem_mb: 16000
   tmp_mb: 48000
   qos: "slow_nice"
+
+heavier_resources: &heavier
+  threads: 8
+  mem_mb: 32000
+  tmp_mb: 64000
+  runtime: 1440
+  qos: "slow_nice"
   
 max_resources: &max
   threads: 16
@@ -358,8 +365,8 @@ resources:
   get_available_bam: *standard
   # ChIPseq
   make_bt2_indices: *heavy
-  bowtie2_map_pe: *heavy
-  bowtie2_map_se: *heavy
+  bowtie2_map_pe: *heavier
+  bowtie2_map_se: *heavier
   filter_chip_pe: *heavy
   filter_chip_se: *heavy
   make_chip_stats_pe: *low
@@ -377,13 +384,13 @@ resources:
   find_motifs_in_file: *heavy
   make_peak_stats: *low
   # ATACseq
-  atac_shift_and_bed: *low
+  atac_shift_and_bed: *standard
   calling_peaks_atac: *heavy
-  make_coverage_atac: *heavy
+  make_coverage_atac: *heavier
   # mC
   make_bismark_indices: *heavy
-  bismark_map_pe: *heavy
-  bismark_map_se: *heavy
+  bismark_map_pe: *heavier
+  bismark_map_se: *heavier
   make_mc_stats_pe: *low
   make_mc_stats_se: *low
   merging_mc_replicates: *heavy
@@ -394,12 +401,12 @@ resources:
   get_bedmethyl: *low
   align_modbam: *max
   modkit_summary: *heavy
-  modkit_pileup: *heavy
+  modkit_pileup: *heavier
   convert_bedmethyl_to_cx_report: *standard
   # RNAseq
   make_STAR_indices: *heavy
-  STAR_map_pe: *heavy
-  STAR_map_se: *heavy
+  STAR_map_pe: *heavier
+  STAR_map_se: *heavier
   filter_rna_pe: *heavy
   filter_rna_se: *heavy
   make_rna_stats_pe: *low
@@ -418,7 +425,7 @@ resources:
   filter_structural_rna: *heavy
   make_bowtie1_indices: *single
   make_bowtie1_indices_large: *single
-  shortstack_map: *heavy
+  shortstack_map: *heavier
   make_cluster_bedfiles: *low
   make_srna_size_stats: *standard
   filter_size_srna_sample: *standard

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -313,39 +313,39 @@ fixed_mchh: 60
 # Resource allocation
 low_resources: &low
   threads: 1
-  mem_mib: 1000
-  tmp_mib: 1000
+  mem_mb: 1000
+  tmp_mb: 1000
   qos: "default"
 
 standard_resources: &standard
   threads: 4
-  mem_mib: 2000
-  tmp_mib: 2000
+  mem_mb: 2000
+  tmp_mb: 2000
   qos: "default"
 
 heavy_resources: &heavy
   threads: 4
-  mem_mib: 16000
-  tmp_mib: 48000
+  mem_mb: 16000
+  tmp_mb: 48000
   qos: "slow_nice"
 
 heavier_resources: &heavier
   threads: 8
-  mem_mib: 32000
-  tmp_mib: 64000
+  mem_mb: 32000
+  tmp_mb: 64000
   runtime: 1440
   qos: "slow_nice"
   
 max_resources: &max
   threads: 16
-  mem_mib: 32000
-  tmp_mib: 96000
+  mem_mb: 32000
+  tmp_mb: 96000
   qos: "slow_nice"
 
 single_thread: &single
   threads: 1
-  mem_mib: 32000
-  tmp_mib: 48000
+  mem_mb: 32000
+  tmp_mb: 48000
   qos: "slow_nice"
   
 resources:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -313,39 +313,39 @@ fixed_mchh: 60
 # Resource allocation
 low_resources: &low
   threads: 1
-  mem_mb: 1000
-  tmp_mb: 1000
+  mem_mib: 1000
+  tmp_mib: 1000
   qos: "default"
 
 standard_resources: &standard
   threads: 4
-  mem_mb: 2000
-  tmp_mb: 2000
+  mem_mib: 2000
+  tmp_mib: 2000
   qos: "default"
 
 heavy_resources: &heavy
   threads: 4
-  mem_mb: 16000
-  tmp_mb: 48000
+  mem_mib: 16000
+  tmp_mib: 48000
   qos: "slow_nice"
 
 heavier_resources: &heavier
   threads: 8
-  mem_mb: 32000
-  tmp_mb: 64000
+  mem_mib: 32000
+  tmp_mib: 64000
   runtime: 1440
   qos: "slow_nice"
   
 max_resources: &max
   threads: 16
-  mem_mb: 32000
-  tmp_mb: 96000
+  mem_mib: 32000
+  tmp_mib: 96000
   qos: "slow_nice"
 
 single_thread: &single
   threads: 1
-  mem_mb: 32000
-  tmp_mb: 48000
+  mem_mib: 32000
+  tmp_mib: 48000
   qos: "slow_nice"
   
 resources:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -371,7 +371,7 @@ resources:
   calling_peaks_macs2_pe: *heavy
   calling_peaks_macs2_se: *heavy
   idr_analysis_replicates: *single
-  merging_chip_replicates: *heavy
+  merging_bt2_replicates: *heavy
   making_pseudo_replicates: *heavy
   best_peaks_pseudoreps: *low
   find_motifs_in_file: *heavy

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -384,7 +384,8 @@ resources:
   find_motifs_in_file: *heavy
   make_peak_stats: *low
   # ATACseq
-  atac_shift_and_bed: *standard
+  atac_shift_bam: *standard
+  atac_bam_to_bed: *low
   calling_peaks_atac: *heavy
   make_coverage_atac: *heavier
   # mC

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -371,7 +371,7 @@ resources:
   calling_peaks_macs2_pe: *heavy
   calling_peaks_macs2_se: *heavy
   idr_analysis_replicates: *single
-  merging_bt2_replicates: *heavy
+  merging_chip_replicates: *heavy
   making_pseudo_replicates: *heavy
   best_peaks_pseudoreps: *low
   find_motifs_in_file: *heavy

--- a/tests/integration/data/test_samples_colcen.tsv
+++ b/tests/integration/data/test_samples_colcen.tsv
@@ -15,3 +15,13 @@ mC	rdr126ddm1	leaf	dmC	rep1	as5-1_Rep1	/grid/martienssen/data/eernst/projects/ep
 mC	rdr126ddm1het	leaf	dmC	rep1	as5-1-wt_Rep1	/grid/martienssen/data/eernst/projects/epicc/epigeneticbutton/test-data-prep/modbams-shimada2024	SE	ColCEN
 mC	rdr126ddm1hp5	leaf	dmC	rep1	as6-1_Rep1	/grid/martienssen/data/eernst/projects/epicc/epigeneticbutton/test-data-prep/modbams-shimada2024	SE	ColCEN
 mC	rdr126ddm1hethp5	leaf	dmC	rep1	as6-1-wt_Rep1	/grid/martienssen/data/eernst/projects/epicc/epigeneticbutton/test-data-prep/modbams-shimada2024	SE	ColCEN
+ATAC	WT	leaf	ATAC	Rep1	SRR12362020	SRA	PE	ColCEN
+ATAC	WT	leaf	ATAC	Rep2	SRR12362021	SRA	PE	ColCEN
+ATAC	WT	leaf	ATAC	Rep3	SRR12362022	SRA	PE	ColCEN
+ATAC	WT	leaf	ATAC	Rep4	SRR12362023	SRA	PE	ColCEN
+ATAC	ddm1	leaf	ATAC	Rep1	SRR12362026	SRA	PE	ColCEN
+ATAC	ddm1	leaf	ATAC	Rep2	SRR12362027	SRA	PE	ColCEN
+ATAC	nrpd1	leaf	ATAC	Rep1	SRR12362044	SRA	PE	ColCEN
+ATAC	nrpd1	leaf	ATAC	Rep2	SRR12362045	SRA	PE	ColCEN
+ATAC	nrpd1	leaf	ATAC	Rep3	SRR12362046	SRA	PE	ColCEN
+ATAC	nrpd1	leaf	ATAC	Rep4	SRR12362047	SRA	PE	ColCEN

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -186,8 +186,10 @@ analysis_samples = (
     [["env", "data_type", "line", "tissue", "sample_type", "ref_genome", "paired", "extra_info"]]
     .drop_duplicates()
 )
-pathtoanalysisfile = os.path.join(REPO_FOLDER,"config",f"analysis_samplefile_{analysis_name}.tsv")
-analysis_samples.to_csv(pathtoanalysisfile, sep="\t", index=False)
+# Write a test-ready sample file (same 9-column format as all_samples.tsv, minus Input rows)
+test_samples = samples.query("sample_type != 'Input'")[colnames]
+pathtoanalysisfile = os.path.join(REPO_FOLDER,"config",f"test_samples_{analysis_name}.tsv")
+test_samples.to_csv(pathtoanalysisfile, sep="\t", index=False, header=False)
     
 # Add a sample_name column to the analysis_sample file
 analysis_samples["sample_name"] = analysis_samples.apply(lambda row: sample_name_str(row, 'analysis'), axis=1)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -186,10 +186,8 @@ analysis_samples = (
     [["env", "data_type", "line", "tissue", "sample_type", "ref_genome", "paired", "extra_info"]]
     .drop_duplicates()
 )
-# Write a test-ready sample file (same 9-column format as all_samples.tsv, minus Input rows)
-test_samples = samples.query("sample_type != 'Input'")[colnames]
-pathtoanalysisfile = os.path.join(REPO_FOLDER,"config",f"test_samples_{analysis_name}.tsv")
-test_samples.to_csv(pathtoanalysisfile, sep="\t", index=False, header=False)
+pathtoanalysisfile = os.path.join(REPO_FOLDER,"config",f"analysis_samplefile_{analysis_name}.tsv")
+analysis_samples.to_csv(pathtoanalysisfile, sep="\t", index=False)
     
 # Add a sample_name column to the analysis_sample file
 analysis_samples["sample_name"] = analysis_samples.apply(lambda row: sample_name_str(row, 'analysis'), axis=1)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -131,6 +131,7 @@ env_patterns = [
     ("sRNA", "sRNA"),
     ("mC", "mC"),
     ("TF_*", "TF"),
+    ("ATAC", "ATAC"),
 ]
 
 # Define sample metadata and avoid header if present
@@ -198,7 +199,7 @@ def all_map_only_input(wildcards):
     
     map_files += expand("results/combined/plots/mapping_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["RNA", "mC"]])
     if not config["aligned_bams"]:
-        map_files += expand("results/combined/plots/mapping_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["ChIP", "TF"]])
+        map_files += expand("results/combined/plots/mapping_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["ChIP", "TF", "ATAC"]])
     map_files += expand("results/combined/plots/srna_sizes_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["sRNA"]])
     
     for _, row in samples.iterrows():
@@ -212,6 +213,7 @@ def all_map_only_input(wildcards):
 include: "rules/environment_setup.smk"
 include: "rules/sample_download.smk"
 include: "rules/ChIPseq.smk"
+include: "rules/ATACseq.smk"
 include: "rules/RNAseq.smk"
 include: "rules/mC.smk"
 include: "rules/smallRNA.smk"
@@ -247,7 +249,8 @@ rule combined_analysis:
         expand("results/TF/chkpts/TF_analysis__{analysis_name}__{ref_genome}.done", analysis_name = analysis_name, ref_genome=REF_GENOMES if "TF" in UNIQUE_ENVS else []),
         expand("results/RNA/chkpts/RNA_analysis__{analysis_name}__{ref_genome}.done", analysis_name = analysis_name, ref_genome=REF_GENOMES if "RNA" in UNIQUE_ENVS else []),
         expand("results/mC/chkpts/mC_analysis__{analysis_name}__{ref_genome}.done", analysis_name = analysis_name, ref_genome=REF_GENOMES if "mC" in UNIQUE_ENVS else []),
-        expand("results/sRNA/chkpts/sRNA_analysis__{analysis_name}__{ref_genome}.done", analysis_name = analysis_name, ref_genome=REF_GENOMES if "sRNA" in UNIQUE_ENVS else [])
+        expand("results/sRNA/chkpts/sRNA_analysis__{analysis_name}__{ref_genome}.done", analysis_name = analysis_name, ref_genome=REF_GENOMES if "sRNA" in UNIQUE_ENVS else []),
+        expand("results/ATAC/chkpts/ATAC_analysis__{analysis_name}__{ref_genome}.done", analysis_name = analysis_name, ref_genome=REF_GENOMES if "ATAC" in UNIQUE_ENVS else [])
     output:
         chkpt = f"results/combined/chkpts/final_analysis__{analysis_name}.done"
     localrule: True

--- a/workflow/envs/epibutton_chip.yaml
+++ b/workflow/envs/epibutton_chip.yaml
@@ -9,3 +9,4 @@ dependencies:
   - bedtools
   - deeptools
   - macs2
+  - pigz

--- a/workflow/rules/ATACseq.smk
+++ b/workflow/rules/ATACseq.smk
@@ -61,7 +61,7 @@ rule atac_shift_and_bed:
     input:
         bamfile = "results/ATAC/mapped/{file_type}__{sample_name}.bam"
     output:
-        bedfile = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bed"
+        bedfile = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bed.gz"
     wildcard_constraints:
         file_type = "final|merged|pseudo1|pseudo2"
     params:
@@ -82,14 +82,15 @@ rule atac_shift_and_bed:
         if [[ ! -f "{input.bamfile}.bai" ]]; then
             samtools index -@ {threads} "{input.bamfile}"
         fi
-        alignmentSieve --ATACshift -b {input.bamfile} -p {threads} --bam /dev/stdout | \
-        bedtools bamtobed -i stdin > {output.bedfile}
+        alignmentSieve --ATACshift -b {input.bamfile} -p {threads} -o /dev/stdout | \
+        bedtools bamtobed -i stdin | \
+        pigz -p {threads} > {output.bedfile}
         }} 2>&1 | tee -a "{log}"
         """
 
 rule calling_peaks_atac:
     input:
-        bedfile = "results/ATAC/mapped/shifted_{file_type}__{data_type}__{line}__{tissue}__{sample_type}__{replicate}__{ref_genome}.bed"
+        bedfile = "results/ATAC/mapped/shifted_{file_type}__{data_type}__{line}__{tissue}__{sample_type}__{replicate}__{ref_genome}.bed.gz"
     output:
         peakfile = "results/ATAC/peaks/peaks_atac__{file_type}__{data_type}__{line}__{tissue}__{sample_type}__{replicate}__{ref_genome}_peaks.narrowPeak"
     params:

--- a/workflow/rules/ATACseq.smk
+++ b/workflow/rules/ATACseq.smk
@@ -57,11 +57,12 @@ def define_final_atac_output(ref_genome):
     return results
 
 
-rule atac_shift_and_bed:
+rule atac_shift_bam:
     input:
         bamfile = "results/ATAC/mapped/{file_type}__{sample_name}.bam"
     output:
-        bedfile = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bed.gz"
+        shifted_bam = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bam",
+        shifted_bai = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bam.bai"
     wildcard_constraints:
         file_type = "final|merged|pseudo1|pseudo2"
     params:
@@ -70,21 +71,43 @@ rule atac_shift_and_bed:
     log:
         temp(return_log_chip("ATAC","{sample_name}", "atac_shift_{file_type}", ""))
     conda: CONDA_ENV_ATAC
-    threads: config["resources"]["atac_shift_and_bed"]["threads"]
+    threads: config["resources"]["atac_shift_bam"]["threads"]
     resources:
-        mem_mb=config["resources"]["atac_shift_and_bed"]["mem_mb"],
-        tmp_mb=config["resources"]["atac_shift_and_bed"]["tmp_mb"],
-        qos=config["resources"]["atac_shift_and_bed"]["qos"]
+        mem_mb=config["resources"]["atac_shift_bam"]["mem_mb"],
+        tmp_mb=config["resources"]["atac_shift_bam"]["tmp_mb"],
+        qos=config["resources"]["atac_shift_bam"]["qos"]
     shell:
         """
         {{
-        printf "\nApplying Tn5 shift and converting to BED for {params.file_type}__{params.sample_name}\n"
-        if [[ ! -f "{input.bamfile}.bai" ]]; then
-            samtools index -@ {threads} "{input.bamfile}"
-        fi
-        alignmentSieve --ATACshift -b {input.bamfile} -p {threads} -o /dev/stdout | \
-        bedtools bamtobed -i stdin | \
-        pigz -p {threads} > {output.bedfile}
+        printf "\nApplying Tn5 shift for {params.file_type}__{params.sample_name}\n"
+        alignmentSieve --ATACshift -b {input.bamfile} -p {threads} -o {output.shifted_bam}
+        samtools index -@ {threads} {output.shifted_bam}
+        }} 2>&1 | tee -a "{log}"
+        """
+
+rule atac_bam_to_bed:
+    input:
+        bamfile = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bam"
+    output:
+        bedfile = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bed.gz"
+    wildcard_constraints:
+        file_type = "final|merged|pseudo1|pseudo2"
+    params:
+        sample_name = lambda wildcards: wildcards.sample_name,
+        file_type = lambda wildcards: wildcards.file_type
+    log:
+        temp(return_log_chip("ATAC","{sample_name}", "atac_bed_{file_type}", ""))
+    conda: CONDA_ENV_ATAC
+    threads: config["resources"]["atac_bam_to_bed"]["threads"]
+    resources:
+        mem_mb=config["resources"]["atac_bam_to_bed"]["mem_mb"],
+        tmp_mb=config["resources"]["atac_bam_to_bed"]["tmp_mb"],
+        qos=config["resources"]["atac_bam_to_bed"]["qos"]
+    shell:
+        """
+        {{
+        printf "\nConverting shifted BAM to BED for {params.file_type}__{params.sample_name}\n"
+        bedtools bamtobed -i {input.bamfile} | pigz -p {threads} > {output.bedfile}
         }} 2>&1 | tee -a "{log}"
         """
 
@@ -120,8 +143,8 @@ rule calling_peaks_atac:
 
 rule make_coverage_atac:
     input:
-        bamfile = "results/ATAC/mapped/{file_type}__{sample_name}.bam",
-        bai = "results/ATAC/mapped/{file_type}__{sample_name}.bam.bai"
+        bamfile = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bam",
+        bai = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bam.bai"
     output:
         bigwig = "results/ATAC/tracks/coverage__{file_type}__{sample_name}.bw"
     wildcard_constraints:

--- a/workflow/rules/ATACseq.smk
+++ b/workflow/rules/ATACseq.smk
@@ -1,0 +1,156 @@
+CONDA_ENV_ATAC=os.path.join(REPO_FOLDER,"workflow","envs","epibutton_chip.yaml")
+
+def define_final_atac_output(ref_genome):
+    qc_option = config["QC_option"]
+    analysis = config['full_analysis']
+    trimmed_fastqs = config['trimmed_fastqs']
+    aligned_bams = config['aligned_bams']
+    map_files = []
+    stat_files = []
+    qc_files = []
+    peak_files = []
+    bigwig_files = []
+
+    filtered_rep_samples = samples[ (samples['env'] == 'ATAC') & (samples['ref_genome'] == ref_genome) ].copy()
+    for _, row in filtered_rep_samples.iterrows():
+        sname = sample_name_str(row, 'sample')
+        paired = get_sample_info_from_name(sname, samples, 'paired')
+        env = "ATAC"
+        if paired == "PE" and not aligned_bams:
+            qc_files.append(f"results/{env}/reports/trim__{sname}__R1_fastqc.html")
+            qc_files.append(f"results/{env}/reports/trim__{sname}__R2_fastqc.html")
+            map_files.append(f"results/{env}/logs/process_chip_pe_sample__{sname}.log")
+            if not trimmed_fastqs:
+                qc_files.append(f"results/{env}/reports/raw__{sname}__R1_fastqc.html")
+                qc_files.append(f"results/{env}/reports/raw__{sname}__R2_fastqc.html")
+        elif paired == "SE" and not aligned_bams:
+            qc_files.append(f"results/{env}/reports/trim__{sname}__R0_fastqc.html")
+            map_files.append(f"results/{env}/logs/process_chip_se_sample__{sname}.log")
+            if not trimmed_fastqs:
+                qc_files.append(f"results/{env}/reports/raw__{sname}__R0_fastqc.html")
+
+    # ATAC has no Input samples to filter out
+    peaktype = config["atac_callpeaks"]["peaktype"]
+    for _, row in filtered_rep_samples.iterrows():
+        sname = sample_name_str(row, 'sample')
+        paired = get_sample_info_from_name(sname, samples, 'paired')
+        bigwig_files.append(f"results/ATAC/tracks/coverage__final__{sname}.bw")
+        peak_files.append(f"results/ATAC/peaks/peaks_atac__final__{sname}_peaks.{peaktype}Peak")
+
+    filtered_analysis_samples = analysis_samples[ (analysis_samples['env'] == 'ATAC') & (analysis_samples['ref_genome'] == ref_genome) ].copy()
+    for _, row in filtered_analysis_samples.iterrows():
+        spname = sample_name_str(row, 'analysis')
+        peak_files.append(f"results/ATAC/peaks/selected_peaks__{spname}.bedPeak")
+        reps = analysis_to_replicates.get((row.data_type, row.line, row.tissue, row.sample_type, row.ref_genome), [])
+        if len(reps) >= 2:
+            bigwig_files.append(f"results/ATAC/tracks/coverage__merged__{row.data_type}__{row.line}__{row.tissue}__{row.sample_type}__merged__{row.ref_genome}.bw")
+            stat_files.append(f"results/ATAC/chkpts/idr__{spname}.done")
+
+    results = map_files + bigwig_files
+
+    if qc_option == "all":
+        results += qc_files
+
+    if analysis:
+        results += peak_files + stat_files
+
+    return results
+
+
+rule atac_shift_and_bed:
+    input:
+        bamfile = "results/ATAC/mapped/{file_type}__{sample_name}.bam"
+    output:
+        bedfile = "results/ATAC/mapped/shifted_{file_type}__{sample_name}.bed"
+    wildcard_constraints:
+        file_type = "final|merged|pseudo1|pseudo2"
+    params:
+        sample_name = lambda wildcards: wildcards.sample_name,
+        file_type = lambda wildcards: wildcards.file_type
+    log:
+        temp(return_log_chip("ATAC","{sample_name}", "atac_shift_{file_type}", ""))
+    conda: CONDA_ENV_ATAC
+    threads: config["resources"]["atac_shift_and_bed"]["threads"]
+    resources:
+        mem_mb=config["resources"]["atac_shift_and_bed"]["mem_mb"],
+        tmp_mb=config["resources"]["atac_shift_and_bed"]["tmp_mb"],
+        qos=config["resources"]["atac_shift_and_bed"]["qos"]
+    shell:
+        """
+        {{
+        printf "\nApplying Tn5 shift and converting to BED for {params.file_type}__{params.sample_name}\n"
+        if [[ ! -f "{input.bamfile}.bai" ]]; then
+            samtools index -@ {threads} "{input.bamfile}"
+        fi
+        alignmentSieve --ATACshift -b {input.bamfile} -p {threads} --bam /dev/stdout | \
+        bedtools bamtobed -i stdin > {output.bedfile}
+        }} 2>&1 | tee -a "{log}"
+        """
+
+rule calling_peaks_atac:
+    input:
+        bedfile = "results/ATAC/mapped/shifted_{file_type}__{data_type}__{line}__{tissue}__{sample_type}__{replicate}__{ref_genome}.bed"
+    output:
+        peakfile = "results/ATAC/peaks/peaks_atac__{file_type}__{data_type}__{line}__{tissue}__{sample_type}__{replicate}__{ref_genome}_peaks.narrowPeak"
+    params:
+        ipname = lambda wildcards: f"{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{wildcards.replicate}__{wildcards.ref_genome}",
+        filetype = lambda wildcards: wildcards.file_type,
+        params = config["atac_callpeaks"]['params'],
+        genomesize = lambda wildcards: config[config[wildcards.ref_genome]['species']]['genomesize']
+    log:
+        temp(return_log_chip("ATAC","{data_type}__{line}__{tissue}__{sample_type}__{replicate}__{ref_genome}", "{file_type}__narrowpeak_calling", "PE"))
+    conda: CONDA_ENV_ATAC
+    threads: config["resources"]["calling_peaks_atac"]["threads"]
+    resources:
+        mem_mb=config["resources"]["calling_peaks_atac"]["mem_mb"],
+        tmp_mb=config["resources"]["calling_peaks_atac"]["tmp_mb"],
+        qos=config["resources"]["calling_peaks_atac"]["qos"]
+    shell:
+        """
+        {{
+        printf "\nCalling narrow peaks for ATAC-seq {params.ipname} using macs2 version:\n"
+        macs2 --version
+        macs2 callpeak -t {input.bedfile} -f BED \
+            -g {params.genomesize} {params.params} \
+            -n peaks_atac__{params.filetype}__{params.ipname} \
+            --outdir results/ATAC/peaks/
+        }} 2>&1 | tee -a "{log}"
+        """
+
+rule make_coverage_atac:
+    input:
+        bamfile = "results/ATAC/mapped/{file_type}__{sample_name}.bam",
+        bai = "results/ATAC/mapped/{file_type}__{sample_name}.bam.bai"
+    output:
+        bigwig = "results/ATAC/tracks/coverage__{file_type}__{sample_name}.bw"
+    wildcard_constraints:
+        file_type = "final|merged"
+    params:
+        binsize = config['atac_tracks']['binsize'],
+        params = config['atac_tracks']['params']
+    log:
+        temp(return_log_chip("ATAC","{sample_name}", "making_coverage_{file_type}", ""))
+    conda: CONDA_ENV_ATAC
+    threads: config["resources"]["make_coverage_atac"]["threads"]
+    resources:
+        mem_mb=config["resources"]["make_coverage_atac"]["mem_mb"],
+        tmp_mb=config["resources"]["make_coverage_atac"]["tmp_mb"],
+        qos=config["resources"]["make_coverage_atac"]["qos"]
+    shell:
+        """
+        {{
+        printf "\nMaking coverage bigwig for ATAC-seq\n"
+        bamCoverage -b {input.bamfile} -o {output.bigwig} -bs {params.binsize} -p {threads} {params.params}
+        }} 2>&1 | tee -a "{log}"
+        """
+
+rule all_atac:
+    input:
+        final = lambda wildcards: define_final_atac_output(wildcards.ref_genome)
+    output:
+        touch = "results/ATAC/chkpts/ATAC_analysis__{analysis_name}__{ref_genome}.done"
+    localrule: True
+    shell:
+        """
+        touch {output.touch}
+        """

--- a/workflow/rules/ATACseq.smk
+++ b/workflow/rules/ATACseq.smk
@@ -153,7 +153,7 @@ rule make_coverage_atac:
         binsize = config['atac_tracks']['binsize'],
         params = config['atac_tracks']['params']
     log:
-        temp(return_log_chip("ATAC","{sample_name}", "making_coverage_{file_type}", ""))
+        temp(return_log_chip("ATAC","{sample_name}", "making_bigwig_{file_type}", ""))
     conda: CONDA_ENV_ATAC
     threads: config["resources"]["make_coverage_atac"]["threads"]
     resources:

--- a/workflow/rules/ChIPseq.smk
+++ b/workflow/rules/ChIPseq.smk
@@ -784,7 +784,7 @@ rule idr_analysis_replicates:
         }} 2>&1 | tee -a "{log}"
         """
 
-rule merging_bt2_replicates:
+rule merging_chip_replicates:
     input:
         bamfiles = lambda wildcards: [ f"results/{wildcards.env}/mapped/final__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{replicate}__{wildcards.ref_genome}.bam" 
                                       for replicate in analysis_to_replicates.get((wildcards.data_type, wildcards.line, wildcards.tissue, wildcards.sample_type, wildcards.ref_genome), []) ]
@@ -800,11 +800,11 @@ rule merging_bt2_replicates:
     log:
         temp(return_log_chip("{env}","{data_type}__{line}__{tissue}__{sample_type}__{ref_genome}", "merging_reps", ""))
     conda: CONDA_ENV_CHIP
-    threads: config["resources"]["merging_bt2_replicates"]["threads"]
+    threads: config["resources"]["merging_chip_replicates"]["threads"]
     resources:
-        mem_mb=config["resources"]["merging_bt2_replicates"]["mem_mb"],
-        tmp_mb=config["resources"]["merging_bt2_replicates"]["tmp_mb"],
-        qos=config["resources"]["merging_bt2_replicates"]["qos"]
+        mem_mb=config["resources"]["merging_chip_replicates"]["mem_mb"],
+        tmp_mb=config["resources"]["merging_chip_replicates"]["tmp_mb"],
+        qos=config["resources"]["merging_chip_replicates"]["qos"]
     shell:
         """
         {{

--- a/workflow/rules/ChIPseq.smk
+++ b/workflow/rules/ChIPseq.smk
@@ -784,7 +784,7 @@ rule idr_analysis_replicates:
         }} 2>&1 | tee -a "{log}"
         """
 
-rule merging_chip_replicates:
+rule merging_bt2_replicates:
     input:
         bamfiles = lambda wildcards: [ f"results/{wildcards.env}/mapped/final__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{replicate}__{wildcards.ref_genome}.bam" 
                                       for replicate in analysis_to_replicates.get((wildcards.data_type, wildcards.line, wildcards.tissue, wildcards.sample_type, wildcards.ref_genome), []) ]
@@ -800,11 +800,11 @@ rule merging_chip_replicates:
     log:
         temp(return_log_chip("{env}","{data_type}__{line}__{tissue}__{sample_type}__{ref_genome}", "merging_reps", ""))
     conda: CONDA_ENV_CHIP
-    threads: config["resources"]["merging_chip_replicates"]["threads"]
+    threads: config["resources"]["merging_bt2_replicates"]["threads"]
     resources:
-        mem_mb=config["resources"]["merging_chip_replicates"]["mem_mb"],
-        tmp_mb=config["resources"]["merging_chip_replicates"]["tmp_mb"],
-        qos=config["resources"]["merging_chip_replicates"]["qos"]
+        mem_mb=config["resources"]["merging_bt2_replicates"]["mem_mb"],
+        tmp_mb=config["resources"]["merging_bt2_replicates"]["tmp_mb"],
+        qos=config["resources"]["merging_bt2_replicates"]["qos"]
     shell:
         """
         {{

--- a/workflow/rules/ChIPseq.smk
+++ b/workflow/rules/ChIPseq.smk
@@ -4,6 +4,18 @@ CONDA_ENV_IDR=os.path.join(REPO_FOLDER,"workflow","envs","epibutton_idr.yaml")
 def return_log_chip(env, sample_name, step, paired):
     return os.path.join(REPO_FOLDER,"results",env,"logs",f"tmp__{sample_name}__{step}__{paired}.log")
 
+def get_bt2_option(env):
+    """Select mapping strategy option based on environment."""
+    if env == "ATAC":
+        return config['atac_mapping_option']
+    return config['chip_mapping_option']
+
+def get_peaktype_for_env(sample_type, env):
+    """Return peaktype using the appropriate config for the environment."""
+    if env == "ATAC":
+        return config["atac_callpeaks"]["peaktype"]
+    return get_peaktype(sample_type, config["chip_callpeaks"]["peaktype"])
+
 def assign_mapping_paired(wildcards, rulename, outputfile):
     sname = wildcards.sample_name
     env = get_sample_info_from_name(sname, samples, 'env')
@@ -59,62 +71,64 @@ def get_peaktype(sample_type, peaktype_config):
 def assign_peak_files_for_idr(wildcards):
     sname = sample_name_str(wildcards, 'analysis')
     paired = get_sample_info_from_name(sname, analysis_samples, 'paired')
-    peaktype = get_peaktype(wildcards.sample_type, config["chip_callpeaks"]["peaktype"])
-    replicates = analysis_to_replicates.get((wildcards.data_type, wildcards.line, wildcards.tissue, wildcards.sample_type, wildcards.ref_genome), [])
     env = get_sample_info_from_name(sname, analysis_samples, 'env')
-    if paired == "PE":
-        return [ f"results/{env}/peaks/peaks_pe__final__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{replicate}__{wildcards.ref_genome}_peaks.{peaktype}Peak"
-                for replicate in replicates ]
+    peaktype = get_peaktype_for_env(wildcards.sample_type, env)
+    replicates = analysis_to_replicates.get((wildcards.data_type, wildcards.line, wildcards.tissue, wildcards.sample_type, wildcards.ref_genome), [])
+    if env == "ATAC":
+        prefix = "peaks_atac"
+    elif paired == "PE":
+        prefix = "peaks_pe"
     else:
-        return [ f"results/{env}/peaks/peaks_se__final__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{replicate}__{wildcards.ref_genome}_peaks.{peaktype}Peak"
-                for replicate in replicates ]
+        prefix = "peaks_se"
+    return [ f"results/{env}/peaks/{prefix}__final__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{replicate}__{wildcards.ref_genome}_peaks.{peaktype}Peak"
+            for replicate in replicates ]
 
 def input_peak_files_for_best_peaks(wildcards):
-    peaktype = get_peaktype(wildcards.sample_type, config["chip_callpeaks"]['peaktype'])
     sname = sample_name_str(wildcards, 'analysis')
     paired = get_sample_info_from_name(sname, analysis_samples, 'paired')
     env = get_sample_info_from_name(sname, analysis_samples, 'env')
+    peaktype = get_peaktype_for_env(wildcards.sample_type, env)
+
+    if env == "ATAC":
+        prefix = "peaks_atac"
+    elif paired == "PE":
+        prefix = "peaks_pe"
+    else:
+        prefix = "peaks_se"
 
     if len(analysis_to_replicates[(wildcards.data_type, wildcards.line, wildcards.tissue, wildcards.sample_type, wildcards.ref_genome)]) >= 2:
-        if paired == "PE":
-            result = [ f"results/{env}/peaks/peaks_pe__merged__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/peaks_pe__pseudo1__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/peaks_pe__pseudo2__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/idr_peaks__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{wildcards.ref_genome}.bed" ]
-        else:
-            result = [ f"results/{env}/peaks/peaks_se__merged__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/peaks_se__pseudo1__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/peaks_se__pseudo2__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/idr_peaks__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{wildcards.ref_genome}.bed" ]
+        result = [ f"results/{env}/peaks/{prefix}__merged__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
+                   f"results/{env}/peaks/{prefix}__pseudo1__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
+                   f"results/{env}/peaks/{prefix}__pseudo2__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__merged__{wildcards.ref_genome}_peaks.{peaktype}Peak",
+                   f"results/{env}/peaks/idr_peaks__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{wildcards.ref_genome}.bed" ]
     else:
         one_rep = analysis_to_replicates.get((wildcards.data_type, wildcards.line, wildcards.tissue, wildcards.sample_type, wildcards.ref_genome), [])[0]
-        if paired == "PE":
-            result = [ f"results/{env}/peaks/peaks_pe__final__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/peaks_pe__pseudo1__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/peaks_pe__pseudo2__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       "results/empty.txt" ]
-        else:
-            result = [ f"results/{env}/peaks/peaks_se__final__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/peaks_se__pseudo1__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       f"results/{env}/peaks/peaks_se__pseudo2__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
-                       "results/empty.txt" ]
+        result = [ f"results/{env}/peaks/{prefix}__final__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
+                   f"results/{env}/peaks/{prefix}__pseudo1__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
+                   f"results/{env}/peaks/{prefix}__pseudo2__{wildcards.data_type}__{wildcards.line}__{wildcards.tissue}__{wildcards.sample_type}__{one_rep}__{wildcards.ref_genome}_peaks.{peaktype}Peak",
+                   "results/empty.txt" ]
 
     return result
 
 def get_replicate_name(wildcards, pos):
     sname = wildcards.sample_name
     paired = get_sample_info_from_name(sname, analysis_samples, 'paired')
-    prefix = "peaks_pe" if paired == "PE" else "peaks_se"
     env = get_sample_info_from_name(sname, analysis_samples, 'env')
+    if env == "ATAC":
+        prefix = "peaks_atac"
+    elif paired == "PE":
+        prefix = "peaks_pe"
+    else:
+        prefix = "peaks_se"
     data_type = get_sample_info_from_name(sname, analysis_samples, 'data_type')
     line = get_sample_info_from_name(sname, analysis_samples, 'line')
     tissue = get_sample_info_from_name(sname, analysis_samples, 'tissue')
     sample_type = get_sample_info_from_name(sname, analysis_samples, 'sample_type')
-    peaktype = get_peaktype(sample_type, config["chip_callpeaks"]["peaktype"])
+    peaktype = get_peaktype_for_env(sample_type, env)
     ref_genome = get_sample_info_from_name(sname, analysis_samples, 'ref_genome')
     rep_list = analysis_to_replicates.get((data_type, line, tissue, sample_type, ref_genome), [])
-    
-    if pos >= len(rep_list): 
+
+    if pos >= len(rep_list):
         return "missingrep"
     else:
         return f"results/{env}/peaks/{prefix}__final__{data_type}__{line}__{tissue}__{sample_type}__{rep_list[pos]}__{ref_genome}_peaks.{peaktype}Peak"
@@ -152,7 +166,7 @@ def define_chipseq_target_file(wildcards):
             return [inputfile, fasta]
     elif file_type.startswith("peaks_"):
         filecat, data_type, line, tissue, sample_type, rep, ref_genome_plus = parts[1:]
-        peaktype = get_peaktype(sample_type, config["chip_callpeaks"]['peaktype'])
+        peaktype = get_peaktype_for_env(sample_type, env)
         inputfile = f"results/{env}/peaks/{file_type}__{filecat}__{data_type}__{line}__{tissue}__{sample_type}__{rep}__{ref_genome_plus}.{peaktype}Peak"
         ref_genome, rest = ref_genome_plus.rsplit("_",1)
         sname = f"{data_type}__{line}__{tissue}__{sample_type}__{rep}__{ref_genome}"
@@ -181,17 +195,18 @@ def define_logs_final_input(wildcards):
     ref_genome = get_sample_info_from_name(sname, analysis_samples, 'ref_genome')
     paired = get_sample_info_from_name(sname, analysis_samples, 'paired')
     env = get_sample_info_from_name(sname, analysis_samples, 'env')
-    peaktype = get_peaktype(sample_type, config["chip_callpeaks"]['peaktype'])
+    peaktype = get_peaktype_for_env(sample_type, env)
     for rep in analysis_to_replicates.get((data_type, line, tissue, sample_type, ref_genome), []):
         namerep = f"{data_type}__{line}__{tissue}__{sample_type}__{rep}__{ref_genome}"
         log_files.append(return_log_chip(env, namerep, f"final__{peaktype}peak_calling", paired))
-        log_files.append(return_log_chip(env, namerep, f"making_bigwig_final", ""))
-        log_files.append(return_log_chip(env, namerep, f"making_fingerprint_final", ""))
-    
+        if env != "ATAC":
+            log_files.append(return_log_chip(env, namerep, f"making_bigwig_final", ""))
+            log_files.append(return_log_chip(env, namerep, f"making_fingerprint_final", ""))
+
     if len(analysis_to_replicates.get((data_type, line, tissue, sample_type, ref_genome), [])) >= 2:
         log_files.append(return_log_chip(env, sname, "IDR", ""))
         log_files.append(return_log_chip(env, sname, "merging_reps", ""))
-        
+
         log_files.append(return_log_chip(env, f"{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}", f"merged__{peaktype}peak_calling", paired))
         log_files.append(return_log_chip(env, f"{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}", f"pseudo1__{peaktype}peak_calling", paired))
         log_files.append(return_log_chip(env, f"{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}", f"pseudo2__{peaktype}peak_calling", paired))
@@ -201,9 +216,9 @@ def define_logs_final_input(wildcards):
         log_files.append(return_log_chip(env, f"{data_type}__{line}__{tissue}__{sample_type}__{one_rep}__{ref_genome}", "splitting_pseudreps", ""))
         log_files.append(return_log_chip(env, f"{data_type}__{line}__{tissue}__{sample_type}__{one_rep}__{ref_genome}", f"pseudo1__{peaktype}peak_calling", paired))
         log_files.append(return_log_chip(env, f"{data_type}__{line}__{tissue}__{sample_type}__{one_rep}__{ref_genome}", f"pseudo2__{peaktype}peak_calling", paired))
-        
+
     log_files.append(return_log_chip(env, f"{data_type}__{line}__{tissue}__{sample_type}__{ref_genome}", "selecting_best_peaks", ""))
-    
+
     return log_files
 
 def define_final_chip_output(ref_genome):
@@ -321,12 +336,12 @@ rule bowtie2_map_pe:
         samfile = temp("results/{env}/mapped/mapped_pe__{sample_name}.sam"),
         metrics = "results/{env}/reports/bt2_pe__{sample_name}.txt"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sample_name = lambda wildcards: wildcards.sample_name,
         ref_genome = lambda wildcards: parse_sample_name(wildcards.sample_name)['ref_genome'],
-        map_option = lambda wildcards: config['chip_mapping_option'],
-        mapping_params = lambda wildcards: config['chip_mapping'][config['chip_mapping_option']]['map_pe']    
+        map_option = lambda wildcards: get_bt2_option(wildcards.env),
+        mapping_params = lambda wildcards: config['bt2_mapping_strategy'][get_bt2_option(wildcards.env)]['map_pe']
     log:
         temp(return_log_chip("{env}","{sample_name}", "mappingBT2", "PE"))
     conda: CONDA_ENV_CHIP
@@ -352,12 +367,12 @@ rule bowtie2_map_se:
         samfile = temp("results/{env}/mapped/mapped_se__{sample_name}.sam"),
         metrics = "results/{env}/reports/bt2_se__{sample_name}.txt"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sample_name = lambda wildcards: wildcards.sample_name,
         ref_genome = lambda wildcards: parse_sample_name(wildcards.sample_name)['ref_genome'],
-        map_option = lambda wildcards: config['chip_mapping_option'],
-        mapping_params = lambda wildcards: config['chip_mapping'][config['chip_mapping_option']]['map_se']    
+        map_option = lambda wildcards: get_bt2_option(wildcards.env),
+        mapping_params = lambda wildcards: config['bt2_mapping_strategy'][get_bt2_option(wildcards.env)]['map_se']
     log:
         temp(return_log_chip("{env}","{sample_name}", "mappingBT2", "SE"))
     conda: CONDA_ENV_CHIP
@@ -383,12 +398,12 @@ rule filter_chip_pe:
         metrics_dup = "results/{env}/reports/markdup_pe__{sample_name}.txt",
         metrics_flag = "results/{env}/reports/flagstat_pe__{sample_name}.txt"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sample_name = lambda wildcards: wildcards.sample_name,
         env = lambda wildcards: wildcards.env,
-        map_option = lambda wildcards: config['chip_mapping_option'],
-        filtering_params = lambda wildcards: config['chip_mapping'][config['chip_mapping_option']]['filter']    
+        map_option = lambda wildcards: get_bt2_option(wildcards.env),
+        filtering_params = lambda wildcards: config['bt2_mapping_strategy'][get_bt2_option(wildcards.env)]['filter']
     log:
         temp(return_log_chip("{env}","{sample_name}", "filteringChIP", "PE"))
     conda: CONDA_ENV_CHIP
@@ -420,12 +435,12 @@ rule filter_chip_se:
         metrics_dup = "results/{env}/reports/markdup_se__{sample_name}.txt",
         metrics_flag = "results/{env}/reports/flagstat_se__{sample_name}.txt"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sample_name = lambda wildcards: wildcards.sample_name,
         env = lambda wildcards: wildcards.env,
-        map_option = lambda wildcards: config['chip_mapping_option'],
-        filtering_params = lambda wildcards: config['chip_mapping'][config['chip_mapping_option']]['filter']    
+        map_option = lambda wildcards: get_bt2_option(wildcards.env),
+        filtering_params = lambda wildcards: config['bt2_mapping_strategy'][get_bt2_option(wildcards.env)]['filter']
     log:
         temp(return_log_chip("{env}","{sample_name}", "filteringChIP", "SE"))
     conda: CONDA_ENV_CHIP
@@ -455,9 +470,9 @@ rule make_chip_stats_pe:
         logs = lambda wildcards: [ return_log_chip(wildcards.env, wildcards.sample_name, step, get_sample_info_from_name(wildcards.sample_name, samples, 'paired')) for step in ["downloading", "trimming", "mappingBT2", "filteringChIP"] ]
     output:
         stat_file = "results/{env}/reports/summary_{env}_PE_mapping_stats_{sample_name}.txt",
-        log = "results/{env}/logs/process_chip_pe_sample__{sample_name}.log"        
+        log = "results/{env}/logs/process_chip_pe_sample__{sample_name}.log"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         line = lambda wildcards: get_sample_info_from_name(wildcards.sample_name, samples, 'line'),
         tissue = lambda wildcards: get_sample_info_from_name(wildcards.sample_name, samples, 'tissue'),
@@ -497,7 +512,7 @@ rule make_chip_stats_se:
         stat_file = "results/{env}/reports/summary_{env}_SE_mapping_stats_{sample_name}.txt",
         log = "results/{env}/logs/process_chip_se_sample__{sample_name}.log"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         line = lambda wildcards: get_sample_info_from_name(wildcards.sample_name, samples, 'line'),
         tissue = lambda wildcards: get_sample_info_from_name(wildcards.sample_name, samples, 'tissue'),
@@ -535,7 +550,7 @@ rule pe_or_se_chip_dispatch:
         bai = "results/{env}/mapped/final__{sample_name}.bam.bai",
         touch = "results/{env}/chkpts/map_{env}__{sample_name}.done"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     conda: CONDA_ENV_CHIP
     threads: config["resources"]["pe_or_se_chip_dispatch"]["threads"]
     resources:
@@ -710,10 +725,10 @@ rule idr_analysis_replicates:
         touch = "results/{env}/chkpts/idr__{data_type}__{line}__{tissue}__{sample_type}__{ref_genome}.done",
         merged = "results/{env}/peaks/idr_peaks__{data_type}__{line}__{tissue}__{sample_type}__{ref_genome}.bed"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sname = lambda wildcards: sample_name_str(wildcards, 'analysis'),
-        peaktype = lambda wildcards: get_peaktype(wildcards.sample_type, config["chip_callpeaks"]["peaktype"]),
+        peaktype = lambda wildcards: get_peaktype_for_env(wildcards.sample_type, wildcards.env),
         paired = lambda wildcards: get_sample_info_from_name(sample_name_str(wildcards, 'analysis'), analysis_samples, 'paired'),
         data_type = lambda wildcards: wildcards.data_type,
         line = lambda wildcards: wildcards.line,
@@ -735,7 +750,9 @@ rule idr_analysis_replicates:
         {{
         printf "\nLooping over each unique pair of biological replicates for {params.sname} to perform IDR with:\n"
         idr --version
-		if [[ "{params.paired}" == "PE" ]]; then
+		if [[ "{params.env}" == "ATAC" ]]; then
+            pre="atac"
+        elif [[ "{params.paired}" == "PE" ]]; then
             pre="pe"
         else
             pre="se"
@@ -775,7 +792,7 @@ rule merging_chip_replicates:
         temp_merge = temp("results/{env}/mapped/temp_merged__{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}.bam"),
         mergefile = "results/{env}/mapped/merged__{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}.bam"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sname = lambda wildcards: sample_name_str(wildcards, 'analysis'),
         env = lambda wildcards: wildcards.env
@@ -806,7 +823,7 @@ rule making_pseudo_replicates:
         pseudo1 = temp("results/{env}/mapped/pseudo1__{data_type}__{line}__{tissue}__{sample_type}__{replicate}__{ref_genome}.bam"),
         pseudo2 = temp("results/{env}/mapped/pseudo2__{data_type}__{line}__{tissue}__{sample_type}__{replicate}__{ref_genome}.bam")
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sname = lambda wildcards: sample_name_str(wildcards, 'analysis'),
         env = lambda wildcards: wildcards.env
@@ -843,11 +860,11 @@ rule best_peaks_pseudoreps:
         bestpeaks = "results/{env}/peaks/selected_peaks__{data_type}__{line}__{tissue}__{sample_type}__{ref_genome}.bedPeak",
         stats_pseudoreps = temp("results/{env}/reports/stats_pseudoreps__{data_type}__{line}__{tissue}__{sample_type}__{ref_genome}.txt")
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sname = lambda wildcards: sample_name_str(wildcards, 'analysis'),
         env = lambda wildcards: wildcards.env,
-        peaktype = lambda wildcards: get_peaktype(wildcards.sample_type, config["chip_callpeaks"]["peaktype"])
+        peaktype = lambda wildcards: get_peaktype_for_env(wildcards.sample_type, wildcards.env)
     log:
         temp(return_log_chip("{env}","{data_type}__{line}__{tissue}__{sample_type}__{ref_genome}", "selecting_best_peaks", ""))
     conda: CONDA_ENV_CHIP
@@ -892,11 +909,11 @@ rule make_peak_stats:
         stat_file = "results/{env}/reports/summary_{env}_peak_stats_{sample_name}.txt",
         log = "results/{env}/logs/called_peaks__{sample_name}.log"
     wildcard_constraints:
-        env = "ChIP|TF"
+        env = "ChIP|TF|ATAC"
     params:
         sname = lambda wildcards: wildcards.sample_name,
         paired = lambda wildcards: get_sample_info_from_name(wildcards.sample_name, analysis_samples, 'paired'),
-        peaktype = lambda wildcards: get_peaktype(get_sample_info_from_name(wildcards.sample_name, analysis_samples, 'sample_type'), config["chip_callpeaks"]["peaktype"]),
+        peaktype = lambda wildcards: get_peaktype_for_env(get_sample_info_from_name(wildcards.sample_name, analysis_samples, 'sample_type'), wildcards.env),
         line = lambda wildcards: get_sample_info_from_name(wildcards.sample_name, analysis_samples, 'line'),
         tissue = lambda wildcards: get_sample_info_from_name(wildcards.sample_name, analysis_samples, 'tissue'),
         sample_type = lambda wildcards: get_sample_info_from_name(wildcards.sample_name, analysis_samples, 'sample_type'),
@@ -923,7 +940,7 @@ rule make_peak_stats:
         idr=$(grep "IDR" {input.stats_pseudoreps} | cut -d"=" -f2)
         selected=$(grep "Selected" {input.stats_pseudoreps} | cut -d"=" -f2)
         printf "Line\tTissue\tMark\tReference_genome\tPeaks_in_Rep1\tPeaks_in_Rep2\tCommon_peaks\tPeaks_in_merged\tPeaks_in_pseudo_reps\tPeaks_in_idr\tSelected_peaks\n" > {output.stat_file}
-        if [[ "{params.env}" == "ChIP" ]]; then
+        if [[ "{params.env}" == "ChIP" ]] || [[ "{params.env}" == "ATAC" ]]; then
             awk -v OFS="\t" -v l={params.line} -v t={params.tissue} -v m={params.sample_type} -v r={params.ref_genome} -v a=${{nrep1}} -v b=${{nrep2}} -v c=${{merged}} -v d=${{pseudos}} -v e=${{idr}} -v f=${{selected}} 'BEGIN {{if (c==0) {{x=a}} else {{x=c}}; print l,t,m,r,a,b,c,d,e,f" ("f/x*100"%)"}}' >> "{output.stat_file}"
         else
             awk -v OFS="\t" -v l={params.line} -v t={params.tissue} -v m={params.tf_name} -v r={params.ref_genome} -v a=${{nrep1}} -v b=${{nrep2}} -v c=${{merged}} -v d=${{pseudos}} -v e=${{idr}} -v f=${{selected}} 'BEGIN {{if (c==0) {{x=a}} else {{x=c}}; print l,t,m,r,a,b,c,d,e,f" ("f/x*100"%)"}}' >> "{output.stat_file}"

--- a/workflow/rules/ChIPseq.smk
+++ b/workflow/rules/ChIPseq.smk
@@ -199,9 +199,9 @@ def define_logs_final_input(wildcards):
     for rep in analysis_to_replicates.get((data_type, line, tissue, sample_type, ref_genome), []):
         namerep = f"{data_type}__{line}__{tissue}__{sample_type}__{rep}__{ref_genome}"
         log_files.append(return_log_chip(env, namerep, f"final__{peaktype}peak_calling", paired))
+        log_files.append(return_log_chip(env, namerep, "making_bigwig_final", ""))
         if env != "ATAC":
-            log_files.append(return_log_chip(env, namerep, f"making_bigwig_final", ""))
-            log_files.append(return_log_chip(env, namerep, f"making_fingerprint_final", ""))
+            log_files.append(return_log_chip(env, namerep, "making_fingerprint_final", ""))
 
     if len(analysis_to_replicates.get((data_type, line, tissue, sample_type, ref_genome), [])) >= 2:
         log_files.append(return_log_chip(env, sname, "IDR", ""))

--- a/workflow/rules/ChIPseq.smk
+++ b/workflow/rules/ChIPseq.smk
@@ -770,6 +770,7 @@ rule idr_analysis_replicates:
             printf "\nPerforming IDR for ${{rep1}} vs ${{rep2}}\n"
             idr --input-file-type {params.peaktype}Peak --output-file-type {params.peaktype}Peak --samples ${{file1}} ${{file2}} -o ${{outfile}} -l results/{params.env}/reports/idr_{params.sname}.log --plot || true
             ## I think "|| true" is to avoid potential pipeline breaking errors if no positive peaks were found
+            mkdir -p results/{params.env}/plots/
             mv "${{outfile}}.png" results/{params.env}/plots/
             filtered="${{outfile}}.filtered"
             awk -v OFS="\t" '$5>=540 {{print $1,$2,$3}}' ${{outfile}} | sort -k1,1 -k2,2n > "${{filtered}}"

--- a/workflow/rules/ChIPseq.smk
+++ b/workflow/rules/ChIPseq.smk
@@ -790,7 +790,8 @@ rule merging_chip_replicates:
                                       for replicate in analysis_to_replicates.get((wildcards.data_type, wildcards.line, wildcards.tissue, wildcards.sample_type, wildcards.ref_genome), []) ]
     output:
         temp_merge = temp("results/{env}/mapped/temp_merged__{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}.bam"),
-        mergefile = "results/{env}/mapped/merged__{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}.bam"
+        mergefile = "results/{env}/mapped/merged__{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}.bam",
+        mergebai = "results/{env}/mapped/merged__{data_type}__{line}__{tissue}__{sample_type}__merged__{ref_genome}.bam.bai"
     wildcard_constraints:
         env = "ChIP|TF|ATAC"
     params:

--- a/workflow/rules/ChIPseq.smk
+++ b/workflow/rules/ChIPseq.smk
@@ -761,6 +761,7 @@ rule idr_analysis_replicates:
         while read chr max; do
             printf "${{chr}}\t1\t${{max}}\n" >> "${{temp}}"
         done < "genomes/{params.ref_genome}/chrom.sizes"
+        mkdir -p results/{params.env}/plots/
         for pair in {params.replicate_pairs}; do
             rep1=$(echo ${{pair}} | cut -d":" -f1)
             rep2=$(echo ${{pair}} | cut -d":" -f2)
@@ -770,7 +771,6 @@ rule idr_analysis_replicates:
             printf "\nPerforming IDR for ${{rep1}} vs ${{rep2}}\n"
             idr --input-file-type {params.peaktype}Peak --output-file-type {params.peaktype}Peak --samples ${{file1}} ${{file2}} -o ${{outfile}} -l results/{params.env}/reports/idr_{params.sname}.log --plot || true
             ## I think "|| true" is to avoid potential pipeline breaking errors if no positive peaks were found
-            mkdir -p results/{params.env}/plots/
             mv "${{outfile}}.png" results/{params.env}/plots/
             filtered="${{outfile}}.filtered"
             awk -v OFS="\t" '$5>=540 {{print $1,$2,$3}}' ${{outfile}} | sort -k1,1 -k2,2n > "${{filtered}}"

--- a/workflow/rules/combined_analysis.smk
+++ b/workflow/rules/combined_analysis.smk
@@ -71,7 +71,7 @@ def define_samplenames_per_env_and_ref(wildcards):
     srna_sizes = config['srna_heatmap_sizes']
     globenv = wildcards.env
     if globenv == "all_chip":
-        filtered_analysis_samples = analysis_samples[ (analysis_samples['env'].isin(["ChIP","TF"])) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
+        filtered_analysis_samples = analysis_samples[ (analysis_samples['env'].isin(["ChIP","TF","ATAC"])) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     else:
         filtered_analysis_samples = analysis_samples[ (analysis_samples['env'] == globenv) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     for _, row in filtered_analysis_samples.iterrows():
@@ -80,12 +80,8 @@ def define_samplenames_per_env_and_ref(wildcards):
             file = f"results/{row.env}/peaks/selected_peaks__{spname}.bedPeak"
             label = f"{row.line}_{row.tissue}_{row.extra_info}"
             names.append(f"{label}:{file}")
-        elif row.env == "ChIP":
+        elif row.env in ["ChIP", "ATAC"]:
             file = f"results/{row.env}/peaks/selected_peaks__{spname}.bedPeak"
-            label = f"{row.line}_{row.tissue}_{row.sample_type}"
-            names.append(f"{label}:{file}")
-        elif row.env == "ATAC":
-            file = f"results/ATAC/peaks/selected_peaks__{spname}.bedPeak"
             label = f"{row.line}_{row.tissue}_{row.sample_type}"
             names.append(f"{label}:{file}")
         elif row.env == "sRNA":
@@ -101,15 +97,13 @@ def define_bedfiles_per_env_and_ref(wildcards):
     ref_genome = wildcards.ref_genome
     globenv = wildcards.env
     if globenv == "all_chip":
-        filtered_analysis_samples = analysis_samples[ (analysis_samples['env'].isin(["ChIP","TF"])) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
-    else:    
+        filtered_analysis_samples = analysis_samples[ (analysis_samples['env'].isin(["ChIP","TF","ATAC"])) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
+    else:
         filtered_analysis_samples = analysis_samples[ (analysis_samples['env'] == globenv) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     for _, row in filtered_analysis_samples.iterrows():
         spname = sample_name_str(row, 'analysis')
-        if globenv in ["all_chip", "ChIP", "TF"]:
+        if globenv in ["all_chip", "ChIP", "TF", "ATAC"]:
             files.append(f"results/{row.env}/peaks/selected_peaks__{spname}.bedPeak")
-        elif globenv == "ATAC":
-            files.append(f"results/ATAC/peaks/selected_peaks__{spname}.bedPeak")
         elif globenv == "sRNA":
             files.extend(f"results/sRNA/mapped/{row.data_type}__{row.line}__{row.tissue}__{row.sample_type}__{replicate}__{row.ref_genome}/clusters.bed"
                                       for replicate in analysis_to_replicates.get((row.data_type, row.line, row.tissue, row.sample_type, row.ref_genome), []))
@@ -121,7 +115,7 @@ def define_sample_types_for_upset(wildcards):
     ref_genome = wildcards.ref_genome
     globenv = wildcards.env
     if globenv == "all_chip":
-        filtered_analysis_samples = analysis_samples[ (analysis_samples['env'].isin(["ChIP","TF"])) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
+        filtered_analysis_samples = analysis_samples[ (analysis_samples['env'].isin(["ChIP","TF","ATAC"])) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     elif globenv in ["ChIP", "TF", "ATAC"]:
         filtered_analysis_samples = analysis_samples[ (analysis_samples['env'] == globenv) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     else:
@@ -129,12 +123,10 @@ def define_sample_types_for_upset(wildcards):
 
     if filtered_analysis_samples is not None:
         for _, row in filtered_analysis_samples.iterrows():
-            if row.env == "ChIP":
+            if row.env in ["ChIP", "ATAC"]:
                 types.add(row.sample_type)
             elif row.env == "TF":
                 types.add(row.extra_info)
-            elif row.env == "ATAC":
-                types.add(row.sample_type)
 
     if globenv == "sRNA":
         srna_min = config['srna_min_size']
@@ -501,7 +493,8 @@ def define_final_combined_output(ref_genome):
     if len(tf_analysis_samples) >=2:
         plot_files.append(f"results/combined/plots/Upset_combined_peaks__TF__{analysis_name}__{ref_genome}.pdf")
     
-    if len(chip_analysis_samples) >=1 and len(tf_analysis_samples) >=1:
+    peak_envs = sum(1 for s in [chip_analysis_samples, tf_analysis_samples, atac_analysis_samples] if len(s) >= 1)
+    if peak_envs >= 2:
         plot_files.append(f"results/combined/plots/Upset_combined_peaks__all_chip__{analysis_name}__{ref_genome}.pdf")
     
     if len(srna_analysis_samples) >=1:

--- a/workflow/rules/combined_analysis.smk
+++ b/workflow/rules/combined_analysis.smk
@@ -72,7 +72,7 @@ def define_samplenames_per_env_and_ref(wildcards):
     globenv = wildcards.env
     if globenv == "all_chip":
         filtered_analysis_samples = analysis_samples[ (analysis_samples['env'].isin(["ChIP","TF"])) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
-    else:    
+    else:
         filtered_analysis_samples = analysis_samples[ (analysis_samples['env'] == globenv) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     for _, row in filtered_analysis_samples.iterrows():
         spname = sample_name_str(row, 'analysis')
@@ -84,12 +84,16 @@ def define_samplenames_per_env_and_ref(wildcards):
             file = f"results/{row.env}/peaks/selected_peaks__{spname}.bedPeak"
             label = f"{row.line}_{row.tissue}_{row.sample_type}"
             names.append(f"{label}:{file}")
+        elif row.env == "ATAC":
+            file = f"results/ATAC/peaks/selected_peaks__{spname}.bedPeak"
+            label = f"{row.line}_{row.tissue}_{row.sample_type}"
+            names.append(f"{label}:{file}")
         elif row.env == "sRNA":
             for replicate in analysis_to_replicates.get((row.data_type, row.line, row.tissue, row.sample_type, row.ref_genome), []):
                 file = f"results/sRNA/mapped/{row.data_type}__{row.line}__{row.tissue}__{row.sample_type}__{replicate}__{row.ref_genome}/clusters.bed"
                 label = f"{row.line}_{row.tissue}_{replicate}"
                 names.append(f"{label}:{file}")
-    
+
     return names
 
 def define_bedfiles_per_env_and_ref(wildcards):
@@ -104,10 +108,12 @@ def define_bedfiles_per_env_and_ref(wildcards):
         spname = sample_name_str(row, 'analysis')
         if globenv in ["all_chip", "ChIP", "TF"]:
             files.append(f"results/{row.env}/peaks/selected_peaks__{spname}.bedPeak")
+        elif globenv == "ATAC":
+            files.append(f"results/ATAC/peaks/selected_peaks__{spname}.bedPeak")
         elif globenv == "sRNA":
-            files.extend(f"results/sRNA/mapped/{row.data_type}__{row.line}__{row.tissue}__{row.sample_type}__{replicate}__{row.ref_genome}/clusters.bed" 
+            files.extend(f"results/sRNA/mapped/{row.data_type}__{row.line}__{row.tissue}__{row.sample_type}__{replicate}__{row.ref_genome}/clusters.bed"
                                       for replicate in analysis_to_replicates.get((row.data_type, row.line, row.tissue, row.sample_type, row.ref_genome), []))
-    
+
     return files
 
 def define_sample_types_for_upset(wildcards):
@@ -116,17 +122,19 @@ def define_sample_types_for_upset(wildcards):
     globenv = wildcards.env
     if globenv == "all_chip":
         filtered_analysis_samples = analysis_samples[ (analysis_samples['env'].isin(["ChIP","TF"])) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
-    elif globenv in ["ChIP", "TF"]:    
+    elif globenv in ["ChIP", "TF", "ATAC"]:
         filtered_analysis_samples = analysis_samples[ (analysis_samples['env'] == globenv) & (analysis_samples['ref_genome'] == ref_genome) ].copy()
-    else: 
+    else:
         filtered_analysis_samples = None
-    
+
     if filtered_analysis_samples is not None:
         for _, row in filtered_analysis_samples.iterrows():
             if row.env == "ChIP":
                 types.add(row.sample_type)
             elif row.env == "TF":
                 types.add(row.extra_info)
+            elif row.env == "ATAC":
+                types.add(row.sample_type)
 
     if globenv == "sRNA":
         srna_min = config['srna_min_size']
@@ -140,11 +148,11 @@ def define_sample_types_for_upset(wildcards):
 
 def define_upset_script(wildcards):
     globenv = wildcards.env
-    if globenv in ["all_chip", "ChIP", "TF"]:
+    if globenv in ["all_chip", "ChIP", "TF", "ATAC"]:
         script = os.path.join(REPO_FOLDER,"workflow","scripts","R_Upset_plot_peaks.R")
     elif globenv == "sRNA":
         script = os.path.join(REPO_FOLDER,"workflow","scripts","R_Upset_plot_clusters.R")
-    
+
     return script
 
 def assign_colors(keys, cmap_name="tab20"):
@@ -169,6 +177,7 @@ def define_key_for_plots(wildcards, string):
     marks = []
     unique_tf = set()
     unique_chip = set()
+    unique_atac = set()
     unique_rna = set()
     unique_srna = set()
     unique_mc = set()
@@ -353,23 +362,46 @@ def define_key_for_plots(wildcards, string):
                         label_to_mark[label] = f"m{context}"
                         label_to_type[label] = f"{row.line}_{row.tissue}"
 
+        elif row.env == "ATAC":
+            if not plot_allreps:
+                merged = f"coverage__merged__{prefix}__merged__{row.ref_genome}.bw"
+                onerep = f"coverage__final__{prefix}__{reps[0]}__{row.ref_genome}.bw"
+                bw = f"results/ATAC/tracks/{merged}" if len(reps) >=2 else f"results/ATAC/tracks/{onerep}"
+                label = f"{row.line}_{row.tissue}_{row.sample_type}"
+                grouped_bw["atac"].append(bw)
+                grouped_labs["atac"].append(label)
+                unique_atac.add("ATAC")
+                label_to_mark[label] = "ATAC"
+                label_to_type[label] = f"{row.line}_{row.tissue}"
+            else:
+                for rep in reps:
+                    bw = f"results/ATAC/tracks/coverage__final__{prefix}__{rep}__{row.ref_genome}.bw"
+                    label = f"{row.line}_{row.tissue}_{row.sample_type}_{rep}"
+                    grouped_bw["atac"].append(bw)
+                    grouped_labs["atac"].append(label)
+                    unique_atac.add("ATAC")
+                    label_to_mark[label] = "ATAC"
+                    label_to_type[label] = f"{row.line}_{row.tissue}"
+
     bigwigs = (
-        sum([grouped_bw.get(f"chip_{chip}", []) for chip in sorted(unique_chip)], []) + 
-        sum([grouped_bw.get(f"tf_{tf}", []) for tf in sorted(unique_tf)], []) + 
-        sum([grouped_bw.get(f"{rna}", []) for rna in sorted(unique_rna)], []) + 
+        sum([grouped_bw.get(f"chip_{chip}", []) for chip in sorted(unique_chip)], []) +
+        sum([grouped_bw.get(f"tf_{tf}", []) for tf in sorted(unique_tf)], []) +
+        sum([grouped_bw.get("atac", [])], []) +
+        sum([grouped_bw.get(f"{rna}", []) for rna in sorted(unique_rna)], []) +
         sum([grouped_bw.get(f"{srna}", []) for srna in sorted(unique_srna)], []) +
         sum([grouped_bw.get(f"{mc}", []) for mc in sorted(unique_mc)], [])
     )
     labels = (
-        sum([grouped_labs.get(f"chip_{chip}", []) for chip in sorted(unique_chip)], []) + 
-        sum([grouped_labs.get(f"tf_{tf}", []) for tf in sorted(unique_tf)], []) + 
-        sum([grouped_labs.get(f"{rna}", []) for rna in sorted(unique_rna)], []) + 
+        sum([grouped_labs.get(f"chip_{chip}", []) for chip in sorted(unique_chip)], []) +
+        sum([grouped_labs.get(f"tf_{tf}", []) for tf in sorted(unique_tf)], []) +
+        sum([grouped_labs.get("atac", [])], []) +
+        sum([grouped_labs.get(f"{rna}", []) for rna in sorted(unique_rna)], []) +
         sum([grouped_labs.get(f"{srna}", []) for srna in sorted(unique_srna)], []) +
         sum([grouped_labs.get(f"{mc}", []) for mc in sorted(unique_mc)], [])
     )
-    marks = ( sorted(unique_chip) + sorted(unique_tf) + [f"{rna}_{strand}" for rna in sorted(unique_rna) for strand in ["plus", "minus"]] + [f"{srna}_{strand}" for srna in sorted(unique_srna) for strand in ["plus", "minus"]] + sorted(unique_mc) ) if strand == "unstranded" else ( sorted(unique_chip) + sorted(unique_tf) + sorted(unique_rna) + sorted(unique_srna) + sorted(unique_mc) )
-    
-    marksforbrowser = ( sorted(unique_chip) + sorted(unique_tf) + sorted(unique_rna) + sorted(unique_srna) + sorted(unique_mc) )
+    marks = ( sorted(unique_chip) + sorted(unique_tf) + sorted(unique_atac) + [f"{rna}_{strand}" for rna in sorted(unique_rna) for strand in ["plus", "minus"]] + [f"{srna}_{strand}" for srna in sorted(unique_srna) for strand in ["plus", "minus"]] + sorted(unique_mc) ) if strand == "unstranded" else ( sorted(unique_chip) + sorted(unique_tf) + sorted(unique_atac) + sorted(unique_rna) + sorted(unique_srna) + sorted(unique_mc) )
+
+    marksforbrowser = ( sorted(unique_chip) + sorted(unique_tf) + sorted(unique_atac) + sorted(unique_rna) + sorted(unique_srna) + sorted(unique_mc) )
     
     types = sorted((filtered_analysis_samples["line"] + "_" + filtered_analysis_samples["tissue"]).tolist())
     
@@ -435,12 +467,12 @@ def define_final_stats_output():
     aligned_bams = config['aligned_bams']
     stat_files = []    
     if not aligned_bams:
-        stat_files += expand("results/combined/plots/mapping_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["ChIP","TF"]])
-    
+        stat_files += expand("results/combined/plots/mapping_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["ChIP","TF","ATAC"]])
+
     stat_files += expand("results/combined/plots/mapping_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["RNA","mC"]])
     stat_files += expand("results/combined/plots/srna_sizes_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["sRNA"]])
-    stat_files += expand("results/combined/plots/peak_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["ChIP","TF"]])
-    
+    stat_files += expand("results/combined/plots/peak_stats_{analysis_name}_{env}.pdf", analysis_name = analysis_name, env=[env for env in UNIQUE_ENVS if env in ["ChIP","TF","ATAC"]])
+
     return stat_files
 
 def define_final_combined_output(ref_genome):
@@ -455,6 +487,7 @@ def define_final_combined_output(ref_genome):
     all_analysis_samples = analysis_samples[ analysis_samples['ref_genome'] == ref_genome ].copy()
     chip_analysis_samples = analysis_samples[ (analysis_samples['env'] == 'ChIP') & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     tf_analysis_samples = analysis_samples[ (analysis_samples['env'] == 'TF') & (analysis_samples['ref_genome'] == ref_genome) ].copy()
+    atac_analysis_samples = analysis_samples[ (analysis_samples['env'] == 'ATAC') & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     mc_analysis_samples = analysis_samples[ (analysis_samples['env'] == 'mC') & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     rna_analysis_samples = analysis_samples[ (analysis_samples['env'] == 'RNA') & (analysis_samples['ref_genome'] == ref_genome) ].copy()
     srna_analysis_samples = analysis_samples[ (analysis_samples['env'] == 'sRNA') & (analysis_samples['ref_genome'] == ref_genome) ].copy()
@@ -473,7 +506,10 @@ def define_final_combined_output(ref_genome):
     
     if len(srna_analysis_samples) >=1:
         plot_files.append(f"results/combined/plots/Upset_combined_clusters__sRNA__{analysis_name}__{ref_genome}.pdf")
-    
+
+    if len(atac_analysis_samples) >=2:
+        plot_files.append(f"results/combined/plots/Upset_combined_peaks__ATAC__{analysis_name}__{ref_genome}.pdf")
+
     if len(mc_analysis_samples) >=1:
         if len(all_analysis_samples) > len(mc_analysis_samples) and mc_sort:
             plot_files.append(f"results/combined/plots/Heatmap_sorted__regions__mC__{analysis_name}__{ref_genome}__all_genes.pdf")

--- a/workflow/scripts/samplefile_validation.py
+++ b/workflow/scripts/samplefile_validation.py
@@ -9,12 +9,10 @@ def validations_patterns(data_type):
         return re.compile(r"^(sRNA|smallRNA|shRNA)$")
     elif data_type == "mC":
         return re.compile(r"^(mC|WGBS|dmC|Pico|EMseq)$")
-    elif data_type == "ATAC":
-        return re.compile(r"^(?!.*\s)(?!.*__)(?!.*').*$")
     elif data_type.startswith("TF_"):
         return re.compile(r"^(IP|IPb|Input)$")
-    elif data_type.startswith("ChIP"):
-        return re.compile(r"^(?!.*\s)(?!.*__)(?!.*').*$")
+    elif data_type.startswith("ChIP") or data_type == "ATAC":
+        return re.compile(r"^(?!.*\s)(?!.*__)(?!.*').+$")
 
 def validate_sample_type(row):
     pattern = validations_patterns(row.data_type)
@@ -35,8 +33,6 @@ def name(row):
 def assign_chip_input(row, tab):
     dtype = row.data_type
     stype = row.sample_type
-    if dtype == "ATAC":
-        return True
     if dtype.startswith("TF") or dtype.startswith("ChIP"):
         if stype != "Input":
             match = tab[

--- a/workflow/scripts/samplefile_validation.py
+++ b/workflow/scripts/samplefile_validation.py
@@ -9,6 +9,8 @@ def validations_patterns(data_type):
         return re.compile(r"^(sRNA|smallRNA|shRNA)$")
     elif data_type == "mC":
         return re.compile(r"^(mC|WGBS|dmC|Pico|EMseq)$")
+    elif data_type == "ATAC":
+        return re.compile(r"^(?!.*\s)(?!.*__)(?!.*').*$")
     elif data_type.startswith("TF_"):
         return re.compile(r"^(IP|IPb|Input)$")
     elif data_type.startswith("ChIP"):
@@ -33,7 +35,9 @@ def name(row):
 def assign_chip_input(row, tab):
     dtype = row.data_type
     stype = row.sample_type
-    if dtype.startswith("TF") or dtype.startswith("ChIP"): 
+    if dtype == "ATAC":
+        return True
+    if dtype.startswith("TF") or dtype.startswith("ChIP"):
         if stype != "Input":
             match = tab[
                 (tab["data_type"]==row.data_type) &


### PR DESCRIPTION
## Summary
- Add full ATAC-seq processing: Tn5 shift correction (alignmentSieve --ATACshift), BED conversion, MACS2 peak calling (no Input control, --shift 75 --extsize 150), CPM-normalized bigwig coverage, and IDR analysis
- Extend shared bowtie2 mapping infrastructure (ChIPseq.smk) to handle ATAC alongside ChIP/TF for mapping, filtering, stats, merging, pseudo-replicates, IDR, and best-peaks
- Integrate ATAC into combined analysis (heatmaps, metaplots, UpSet plots) and sample validation
- Add ATAC-seq test samples (WT, ddm1, nrpd1) from SRP274617
- Add heavier resource tier with 24h runtime to prevent SLURM timeouts on large mapping jobs

## Changes
- **New file:** `workflow/rules/ATACseq.smk` — ATAC-specific rules and output function
- **`workflow/rules/ChIPseq.smk`** — Widened wildcard constraints to `ChIP|TF|ATAC` for shared rules, added ATAC-aware helper functions, declared merged BAM index as formal output, moved IDR mkdir -p before loop, added ATAC bigwig log collection
- **`workflow/rules/combined_analysis.smk`** — Added ATAC to `all_chip` combined analysis group across all helper functions, merged ATAC branches into existing ChIP/TF cases
- **`workflow/Snakefile`** — Registered ATAC environment, included ATACseq.smk, added ATAC checkpoints
- **`config/config.yaml`** — Added ATAC config blocks, heavier resource tier with 24h runtime, separate resource entries for atac_shift_bam and atac_bam_to_bed
- **`workflow/envs/epibutton_chip.yaml`** — Added pigz for parallel gzip
- **`workflow/scripts/samplefile_validation.py`** — Combined ATAC/ChIP sample_type validation into single case with non-empty check, removed redundant ATAC early-return in assign_chip_input
- **`tests/integration/data/test_samples_colcen.tsv`** — Added 10 ATAC-seq samples from SRP274617

## Review feedback addressed
- [x] Declare shifted BAM .bai as formal output (split atac_shift_and_bed into atac_shift_bam + atac_bam_to_bed)
- [x] Move IDR mkdir -p before loop (directory() not suitable since plots/ is shared across rules)
- [x] Merge ATAC elif into ChIP/TF cases in combined_analysis helpers
- [x] Add ATAC to all_chip group for cross-datatype UpSet plots
- [x] Remove useless ATAC check in assign_chip_input
- [x] Add non-empty assertion to ATAC/ChIP validation regex, combine into single case
- [x] Align ATAC bigwig log name with ChIP convention and collect it
- [ ] Runtime in resource tiers + profile (deferred to restructure)

## Test plan
- [x] Dry run completes without errors
- [x] ATAC samples download, map, filter, and generate stats
- [x] Tn5 shift + BED conversion produces gzipped output
- [x] MACS2 peak calling runs without Input control
- [x] IDR analysis completes for all multi-replicate samples (WT, ddm1, nrpd1)
- [x] CPM bigwig coverage generated
- [x] Combined analysis heatmaps/metaplots include ATAC tracks
- [x] Full pipeline run completes (50/50 steps, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)