### PR TITLE
feat(output): add --background to `epicc output --plot-type go` (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,18 @@ epicc output --plot-type go \
   --plot-label my_genes_of_interest \
   --ref-genome ColCEN
 ```
+By default the enrichment background (the reference gene set tested against) is
+all genes in the genome. To restrict it — e.g. to only the genes expressed in
+your experiment — pass a gene-ID file with `--background`:
+```bash
+epicc output --plot-type go \
+  --input-file data/target_genes.txt \
+  --plot-label my_genes_of_interest \
+  --ref-genome ColCEN \
+  --background data/expressed_genes.txt
+```
+(`--background` sets `rnaseq_background_file` for this run; it is a tab-delimited
+file whose first column is gene IDs matching the reference GFF.)
 Output includes two pdf treemaps (`topGO_<label>_BP_treemap.pdf` for biological process and `topGO_<label>_MF_treemap.pdf` for molecular function) and corresponding enrichment tables under `results/RNA/GO/`.
 
 ### **3. Finding motifs on target regions**

--- a/config/epicc-options.yaml
+++ b/config/epicc-options.yaml
@@ -471,7 +471,7 @@ motif_ref_genome: "ColCEN" # Reference genome corresponding to the motif target 
 # gene expression plots
 rnaseq_target_file_label: "target_genes" # This name will be used for the name of the results files and should used in the rule target.
 rnaseq_target_file: "data/target_genes.txt" # tab-delimited file listing genes in rows where the first column is GID (matching the gene IDs in the reference genome gff) and optionally the second column are labels (see example). Other columns will be ignored.
-rnaseq_background_file: "default" # tab-delimited file with a column of GID (matching the gene IDs in the reference genome gff). Other columns will be ignored. Will be used as background for GO enrichment analysis. Default is all genes.
+rnaseq_background_file: "default" # tab-delimited file with a column of GID (matching the gene IDs in the reference genome gff). Other columns will be ignored. Will be used as background for GO enrichment analysis. Default is all genes. Can also be set per-run via `epicc output --plot-type go --background FILE`.
 
 # sRNA diffenrential expression analysis
 srna_target_file_label: "miRNAs" # This name will be used for the results folder and should be used in the rule target.

--- a/epicc
+++ b/epicc
@@ -1088,6 +1088,12 @@ def cmd_output(args, extra_args):
     # --- Validate input file format
     validate_output_input(args.input_file, spec["format"])
 
+    # --- Optional GO background file (--plot-type go only)
+    if getattr(args, "background", None):
+        if args.plot_type != "go":
+            sys.exit("Error: --background is only valid with --plot-type go.")
+        validate_output_input(args.background, "tsv_geneids")
+
     # --- Load options to resolve analysis_name / output_dir defaults
     try:
         import yaml
@@ -1143,6 +1149,8 @@ def cmd_output(args, extra_args):
         config_overrides.append(f"{cfg_key}={sources[source]}")
     if args.analysis_name:
         config_overrides.append(f"analysis_name={analysis_name}")
+    if getattr(args, "background", None):
+        config_overrides.append(f"rnaseq_background_file={args.background}")
 
     # --- Build snakemake command (re-uses the same execution-mode logic)
     cmd = ["snakemake"]
@@ -1653,6 +1661,13 @@ def build_parser():
         "--plot-label", metavar="LABEL",
         help="Label embedded in output filenames. Defaults to the input "
              "file's basename without extension.",
+    )
+    p_out.add_argument(
+        "--background", metavar="PATH",
+        help="Optional gene-ID background file for GO enrichment "
+             "(--plot-type go only): tab-delimited with gene IDs in the first "
+             "column. Sets rnaseq_background_file for this run. Default "
+             "background is all genes in the genome.",
     )
     p_out.add_argument(
         "--analysis-name", metavar="NAME",

--- a/tests/unit/test_epicc_output.py
+++ b/tests/unit/test_epicc_output.py
@@ -156,3 +156,26 @@ class TestValidateOutputInput:
         with gzip.open(f, "wt") as fh:
             fh.write("chrI\t10\t100\tn1\n")
         epicc.validate_output_input(str(f), "bed")
+
+
+# ---------------------------------------------------------------------------
+# `epicc output --background` (optional GO enrichment background file)
+# ---------------------------------------------------------------------------
+
+class TestBackgroundArg:
+    def test_background_parsed_for_go(self):
+        parser = epicc.build_parser()
+        args = parser.parse_args([
+            "output", "--plot-type", "go",
+            "--input-file", "genes.txt",
+            "--background", "bg.txt",
+        ])
+        assert args.background == "bg.txt"
+
+    def test_background_defaults_to_none(self):
+        parser = epicc.build_parser()
+        args = parser.parse_args([
+            "output", "--plot-type", "go",
+            "--input-file", "genes.txt",
+        ])
+        assert args.background is None


### PR DESCRIPTION
Closes #40.

## What #40 asked
Add a way to set the GO enrichment background file when running
`epicc output --plot-type go`, since the pipeline supports one
(`rnaseq_background_file` → `define_rnaseq_background_file` →
`perform_GO_on_target_file`) but it was only settable by hand-editing the
options YAML.

## Changes
- **`--background PATH`** on `epicc output`:
  - accepted only with `--plot-type go` (clear error otherwise),
  - validated as a gene-ID (`tsv_geneids`) file,
  - passed through as a `rnaseq_background_file=` `--config` override.
- README `go` example extended to show `--background`.
- `epicc-options.yaml` comment expanded to mention the flag.
- Unit tests for the new argument.

## How it wires through
`epicc output` sets `rnaseq_target_file_label` = the plot label, which is the
`{target_name}` wildcard of the GO rule. So in `define_rnaseq_background_file`,
`target_name == rnaseq_target_file_label` and the provided file exists → it's
returned as the background. Default behavior (all genes) is unchanged when
`--background` is omitted.

## On "missing from epicc-options"
`rnaseq_background_file` **already exists** in `config/epicc-options.yaml`
(present since the config→options rename, 21918b7), so the shipped options file
was not actually missing it. The likely source of that observation: the
**epicc-builder Options form exposes no rnaseq/GO target fields at all**
(`rnaseq_target_file`, `rnaseq_target_file_label`, `rnaseq_background_file` are
in the builder's import/export key lists but have no form inputs), so an
options file built from scratch in the builder omits them. That's a separate,
design-level decision about the builder's scope — flagged for discussion, not
changed here.

## Testing
- `pytest tests/unit/test_epicc_output.py` → 20 passed (incl. 2 new).
- `epicc` + `samplefile_validation.py` compile clean.