### PR TITLE
feat(builder): add Target Files section for output/plot region lists

### DIFF
--- a/tools/epicc-builder.html
+++ b/tools/epicc-builder.html
@@ -2949,8 +2949,12 @@ function buildConfigForm() {
   container.appendChild(tgtDet);
 
   // --- Footer ---
-  container.appendChild(el("div", { className: "cfg-footer",
-    textContent: "More options are available to those who can directly change the yamls... \uD83E\uDD13" }));
+  // Keep the trailing emoji upright \u2014 .cfg-footer italicizes its text, which
+  // synthetically slants the emoji on some platforms.
+  container.appendChild(el("div", { className: "cfg-footer" }, [
+    "More options are available to those who can directly change the yamls... ",
+    el("span", { style: "font-style: normal", textContent: "\uD83E\uDD13" })
+  ]));
   _configFormBuilt = true;
 }
 

--- a/tools/epicc-builder.html
+++ b/tools/epicc-builder.html
@@ -2467,6 +2467,19 @@ var configState = {
   profiles_plot_params: "--plotType lines",
   browser_TE_file: true,
   browser_scales: "sample",
+  // Target files for outputs & plots (per-output-type region/gene lists)
+  rnaseq_target_file_label: "target_genes",
+  rnaseq_target_file: "data/target_genes.txt",
+  rnaseq_background_file: "default",
+  motif_target_file_label: "target_motifs",
+  motif_target_file: "data/target_genes.bed",
+  motif_ref_genome: "",
+  srna_target_file_label: "miRNAs",
+  srna_target_file: "config/ath.gff3",
+  heatmap_target_file_label: "target_genes",
+  heatmap_target_file: "data/target_genes.bed",
+  browser_target_file_label: "target_loci",
+  browser_target_file: "data/target_loci.bed",
   // Dynamic — keyed by genome name
   genomes: {},
 };
@@ -2886,6 +2899,51 @@ function buildConfigForm() {
   plotDet.appendChild(plotBody);
   container.appendChild(plotDet);
 
+  // --- Target files for outputs & plots ---
+  // Region/gene lists that drive per-output-type products, both during a full
+  // run and via `epicc output --plot-type ...`. Each *_label is embedded in the
+  // output filenames; each *_file points at the input regions/genes.
+  var tgtDet = el("details", { className: "cfg-details" });
+  tgtDet.appendChild(el("summary", { textContent: "📄 Target Files for Outputs & Plots" }));
+  var tgtBody = el("div", { className: "cfg-details-body" });
+
+  tgtBody.appendChild(el("h3", { textContent: "RNA-seq / GO" }));
+  tgtBody.appendChild(buildTextRow("Gene list label:", "rnaseq_target_file_label", "target_genes",
+    "Embedded in RNA-seq expression / GO output filenames."));
+  tgtBody.appendChild(buildTextRow("Gene list file:", "rnaseq_target_file", "data/target_genes.txt",
+    "Tab-delimited; first column = gene IDs matching the reference GFF (optional 2nd column = labels)."));
+  tgtBody.appendChild(buildTextRow("GO background file:", "rnaseq_background_file", "default",
+    "Gene-ID file used as the GO enrichment background. \"default\" = all genes in the genome."));
+
+  tgtBody.appendChild(el("h3", { textContent: "Motifs" }));
+  tgtBody.appendChild(buildTextRow("Motif regions label:", "motif_target_file_label", "target_motifs",
+    "Embedded in motif-analysis output filenames."));
+  tgtBody.appendChild(buildTextRow("Motif regions file:", "motif_target_file", "data/target_genes.bed",
+    "BED file of regions to scan for motifs."));
+  tgtBody.appendChild(buildTextRow("Motif reference genome:", "motif_ref_genome", "e.g. ColCEN",
+    "Name of a configured genome (must match one defined in the Reference Genomes tab)."));
+
+  tgtBody.appendChild(el("h3", { textContent: "sRNA clusters" }));
+  tgtBody.appendChild(buildTextRow("sRNA regions label:", "srna_target_file_label", "miRNAs",
+    "Embedded in sRNA-cluster output folder names."));
+  tgtBody.appendChild(buildTextRow("sRNA regions file:", "srna_target_file", "config/ath.gff3",
+    "Target regions for sRNA analysis (tab-delimited, .bed, or .gff3)."));
+
+  tgtBody.appendChild(el("h3", { textContent: "Heatmap / metaplot" }));
+  tgtBody.appendChild(buildTextRow("Heatmap regions label:", "heatmap_target_file_label", "target_genes",
+    "Embedded in heatmap / metaplot output filenames."));
+  tgtBody.appendChild(buildTextRow("Heatmap regions file:", "heatmap_target_file", "data/target_genes.bed",
+    "BED file of regions for heatmaps/metaplots (may include a header)."));
+
+  tgtBody.appendChild(el("h3", { textContent: "Browser" }));
+  tgtBody.appendChild(buildTextRow("Browser regions label:", "browser_target_file_label", "target_loci",
+    "Embedded in browser-shot output filenames."));
+  tgtBody.appendChild(buildTextRow("Browser regions file:", "browser_target_file", "data/target_loci.bed",
+    "BED file of regions for browser shots; one region per PDF page (may include a header)."));
+
+  tgtDet.appendChild(tgtBody);
+  container.appendChild(tgtDet);
+
   // --- Footer ---
   container.appendChild(el("div", { className: "cfg-footer",
     textContent: "More options are available to those who can directly change the yamls... \uD83E\uDD13" }));
@@ -3085,6 +3143,20 @@ function configStateToYAML() {
   cfg.browser_TE_file = configState.browser_TE_file;
   cfg.browser_scales = configState.browser_scales;
 
+  // Target files for outputs & plots
+  cfg.rnaseq_target_file_label = configState.rnaseq_target_file_label;
+  cfg.rnaseq_target_file = configState.rnaseq_target_file;
+  cfg.rnaseq_background_file = configState.rnaseq_background_file;
+  cfg.motif_target_file_label = configState.motif_target_file_label;
+  cfg.motif_target_file = configState.motif_target_file;
+  cfg.motif_ref_genome = configState.motif_ref_genome;
+  cfg.srna_target_file_label = configState.srna_target_file_label;
+  cfg.srna_target_file = configState.srna_target_file;
+  cfg.heatmap_target_file_label = configState.heatmap_target_file_label;
+  cfg.heatmap_target_file = configState.heatmap_target_file;
+  cfg.browser_target_file_label = configState.browser_target_file_label;
+  cfg.browser_target_file = configState.browser_target_file;
+
   return cfg;
 }
 
@@ -3165,6 +3237,20 @@ function handleYAMLImport(text) {
   if (cfg.profiles_plot_params != null) configState.profiles_plot_params = cfg.profiles_plot_params;
   if (cfg.browser_TE_file != null) configState.browser_TE_file = !!cfg.browser_TE_file;
   if (cfg.browser_scales != null) configState.browser_scales = cfg.browser_scales;
+
+  // Target files for outputs & plots
+  if (cfg.rnaseq_target_file_label != null) configState.rnaseq_target_file_label = cfg.rnaseq_target_file_label;
+  if (cfg.rnaseq_target_file != null) configState.rnaseq_target_file = cfg.rnaseq_target_file;
+  if (cfg.rnaseq_background_file != null) configState.rnaseq_background_file = cfg.rnaseq_background_file;
+  if (cfg.motif_target_file_label != null) configState.motif_target_file_label = cfg.motif_target_file_label;
+  if (cfg.motif_target_file != null) configState.motif_target_file = cfg.motif_target_file;
+  if (cfg.motif_ref_genome != null) configState.motif_ref_genome = cfg.motif_ref_genome;
+  if (cfg.srna_target_file_label != null) configState.srna_target_file_label = cfg.srna_target_file_label;
+  if (cfg.srna_target_file != null) configState.srna_target_file = cfg.srna_target_file;
+  if (cfg.heatmap_target_file_label != null) configState.heatmap_target_file_label = cfg.heatmap_target_file_label;
+  if (cfg.heatmap_target_file != null) configState.heatmap_target_file = cfg.heatmap_target_file;
+  if (cfg.browser_target_file_label != null) configState.browser_target_file_label = cfg.browser_target_file_label;
+  if (cfg.browser_target_file != null) configState.browser_target_file = cfg.browser_target_file;
 
   // Trimming/adapter nested objects (fastp)
   if (cfg.quality_threshold) {

--- a/tools/epicc-builder.html
+++ b/tools/epicc-builder.html
@@ -2920,8 +2920,12 @@ function buildConfigForm() {
     "Embedded in motif-analysis output filenames."));
   tgtBody.appendChild(buildTextRow("Motif regions file:", "motif_target_file", "data/target_genes.bed",
     "BED file of regions to scan for motifs."));
-  tgtBody.appendChild(buildTextRow("Motif reference genome:", "motif_ref_genome", "e.g. ColCEN",
-    "Name of a configured genome (must match one defined in the Reference Genomes tab)."));
+  // Dropdown populated from the defined genomes; refreshed on each Options-tab
+  // visit by refreshMotifGenomeOptions() (the form itself is built only once).
+  tgtBody.appendChild(buildSelectRow("Motif reference genome:", "motif_ref_genome",
+    getDefinedGenomes(),
+    "Must match a genome defined in the Reference Genomes tab. This list "
+    + "refreshes each time you open the Options tab."));
 
   tgtBody.appendChild(el("h3", { textContent: "sRNA clusters" }));
   tgtBody.appendChild(buildTextRow("sRNA regions label:", "srna_target_file_label", "miRNAs",
@@ -2967,10 +2971,36 @@ function getGenomesFromSampleSheet() {
 
 // Get unique species names from genome config
 // Rebuild dynamic config sections (genomes are now in their own tab)
+// Repopulate the motif reference-genome dropdown from the currently-defined
+// genomes. Called on every switch to the Options tab: the config form is built
+// only once, so a static option list would go stale as genomes are added or
+// removed in the Reference Genomes tab.
+function refreshMotifGenomeOptions() {
+  var sel = document.getElementById("cfg-motif_ref_genome");
+  if (!sel) return;
+  var current = configState.motif_ref_genome || "";
+  var genomes = getDefinedGenomes();
+  // Preserve a stored value that isn't among the defined genomes (e.g. imported
+  // from a YAML, or a genome removed after selection) so it isn't silently lost.
+  if (current && genomes.indexOf(current) === -1) {
+    genomes = [current].concat(genomes);
+  }
+  while (sel.firstChild) sel.removeChild(sel.firstChild);
+  sel.appendChild(el("option", {
+    value: "",
+    textContent: genomes.length ? "— select genome —" : "— define a genome first —"
+  }));
+  for (var i = 0; i < genomes.length; i++) {
+    sel.appendChild(el("option", { value: genomes[i], textContent: genomes[i] }));
+  }
+  sel.value = current;
+}
+
 function updateConfigDynamicSections() {
   if (!_configFormBuilt) {
     buildConfigForm();
   }
+  refreshMotifGenomeOptions();
 }
 
 // ===========================================================================


### PR DESCRIPTION
Follow-up to #40. The epicc-builder Options form exposed **none** of the
per-output target-file keys, so an options file built from scratch omitted them
— the likely source of the "rnaseq_background_file missing from epicc-options"
observation in #40.

## What's added
A dedicated collapsible **"Target Files for Outputs & Plots"** section covering
all five output families (12 keys):

| Family | Keys |
|--------|------|
| RNA-seq / GO | `rnaseq_target_file`, `rnaseq_target_file_label`, `rnaseq_background_file` |
| Motifs | `motif_target_file`, `motif_target_file_label`, `motif_ref_genome` |
| sRNA clusters | `srna_target_file`, `srna_target_file_label` |
| Heatmap / metaplot | `heatmap_target_file`, `heatmap_target_file_label` |
| Browser | `browser_target_file`, `browser_target_file_label` |

## Wiring
These keys were previously **unwired** (present only in the old-format import
fallback's key detector). This wires all 12 through the four places the builder
handles config: `configState` defaults, the form, YAML export, and YAML import.

## `motif_ref_genome` is a dynamic dropdown
Populated from `getDefinedGenomes()` (manually-added genomes + those in the
sample sheet). Since the config form builds only once, `refreshMotifGenomeOptions()`
repopulates the dropdown on every switch to the Options tab (via
`updateConfigDynamicSections`), preserving the current selection — including a
stored value not in the current list (e.g. imported from YAML), so nothing is
silently lost. Shows a "define a genome first" placeholder when none exist.

## Also
- Footer emoji kept upright: `.cfg-footer` italicizes its text, which
  synthetically slants the trailing emoji; it now sits in its own
  `font-style: normal` span.
- Defaults mirror `config/epicc-options.yaml`, so a from-scratch export matches
  the shipped template.

## Verification
- App inline script passes `node --check`; all 12 keys present in
  defaults + export + import + a form field.
- **Please verify in-browser**: Options tab shows the section; the motif genome
  dropdown lists your defined genomes (and updates after you add one in the
  Reference Genomes tab); Export YAML includes the 12 keys; import round-trips.